### PR TITLE
Add placeholder comment to calendar head

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Focus Flow Calendar</title>
+  <!-- TODO: consider adding analytics script in future -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add a placeholder HTML comment in the calendar head to serve as an inactive line of code

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d6d47daec4832e8e76e0087580672a