### PR TITLE
Improve calendar picker defaults and mission critical styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,16 +603,20 @@
 
     @keyframes day-pulse {
       0% {
-        opacity: 0.85;
-        transform: scale(0.9);
+        opacity: 0.9;
+        transform: scale(0.88);
       }
-      55% {
-        opacity: 0.35;
-        transform: scale(1.12);
+      45% {
+        opacity: 0.55;
+        transform: scale(1.1);
+      }
+      72% {
+        opacity: 0.25;
+        transform: scale(1.18);
       }
       100% {
         opacity: 0;
-        transform: scale(1.28);
+        transform: scale(1.24);
       }
     }
 
@@ -622,7 +626,7 @@
 
     .day.highlight-pulse::before {
       opacity: 1;
-      animation: day-pulse 1.1s ease-out;
+      animation: day-pulse 1.85s ease-out forwards;
     }
 
     .day:is(:hover, .drag-over, .show-flyout) {
@@ -733,8 +737,7 @@
     }
 
     .task-preview-bar.mission-critical {
-      box-shadow: 0 0 0 2px rgba(255, 196, 0, 0.5),
-                  0 0 12px rgba(255, 196, 0, 0.3);
+      box-shadow: none;
     }
 
     .task-preview-bar::after {
@@ -869,9 +872,8 @@
     }
 
     .task-card.mission-critical {
-      border-color: rgba(255, 214, 64, 0.85);
-      box-shadow: 0 0 0 1px rgba(255, 196, 0, 0.45),
-                  0 26px 46px rgba(255, 196, 0, 0.18);
+      border-color: var(--task-outline, rgba(255, 255, 255, 0.24));
+      box-shadow: 0 22px 44px rgba(0, 0, 0, 0.35);
     }
 
     .task-title {
@@ -944,8 +946,8 @@
     }
 
     .task-detail.mission-critical {
-      color: rgba(255, 214, 64, 0.92);
-      text-shadow: 0 0 12px rgba(255, 214, 64, 0.35);
+      color: rgba(255, 255, 255, 0.68);
+      text-shadow: none;
     }
 
     .task-note-line {
@@ -1150,6 +1152,7 @@
       transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
       font-size: 13px;
       letter-spacing: 0.02em;
+      color: var(--text);
     }
 
     .category-chip:hover,
@@ -1687,6 +1690,23 @@
         return target;
       }
 
+      function scrollToValue(value, { focus = false } = {}) {
+        const normalized = value == null ? '' : String(value);
+        const option = optionMap.get(normalized);
+        if (!option) return null;
+        const offset = option.offsetTop - pickerEl.clientHeight / 2 + option.offsetHeight / 2;
+        pickerEl.scrollTop = Math.max(0, offset);
+        if (focus) {
+          option.focus({ preventScroll: true });
+        }
+        return option;
+      }
+
+      function scrollToDefault({ focus = false } = {}) {
+        if (!defaultFocusValue || !optionMap.has(defaultFocusValue)) return null;
+        return scrollToValue(defaultFocusValue, { focus });
+      }
+
       function handlePickerKeydown(event) {
         const options = Array.from(pickerEl.querySelectorAll('.time-option'));
         if (!options.length) return;
@@ -1737,16 +1757,18 @@
         });
         displayEl.setAttribute('aria-expanded', 'true');
         const currentValue = hiddenInput.value || '';
-        let focusTarget = optionMap.get(currentValue);
-        if (!focusTarget && !currentValue && defaultFocusValue && optionMap.has(defaultFocusValue)) {
-          focusTarget = optionMap.get(defaultFocusValue);
-        }
-        if (!focusTarget) {
-          focusTarget = pickerEl.querySelector('.time-option');
-        }
-        if (focusTarget) {
-          focusTarget.focus({ preventScroll: true });
-          focusTarget.scrollIntoView({ block: 'center' });
+        let focusTarget = null;
+        if (currentValue && optionMap.has(currentValue)) {
+          focusTarget = optionMap.get(currentValue);
+          focusTarget?.focus({ preventScroll: true });
+          focusTarget?.scrollIntoView({ block: 'center' });
+        } else {
+          focusTarget = scrollToDefault({ focus: true });
+          if (!focusTarget) {
+            focusTarget = pickerEl.querySelector('.time-option');
+            focusTarget?.focus({ preventScroll: true });
+            focusTarget?.scrollIntoView({ block: 'center' });
+          }
         }
         document.addEventListener('pointerdown', handleOutsidePointer, true);
         document.addEventListener('keydown', handleGlobalKeydown, true);
@@ -1808,6 +1830,8 @@
       return {
         setValue,
         ensureOption,
+        scrollToDefault,
+        scrollToValue,
         open,
         close,
         rebuild
@@ -2234,6 +2258,9 @@
           startPickerController.ensureOption(startValue, startValue);
         }
         startPickerController.setValue(startValue, { scrollIntoView: Boolean(startValue) });
+        if (!startValue) {
+          startPickerController.scrollToDefault({ focus: false });
+        }
       } else if (taskStartInput) {
         taskStartInput.value = startValue;
       }
@@ -2413,6 +2440,18 @@
           const dayNumber = i - startWeekday + 1;
           if (dayNumber < 1 || dayNumber > daysInMonth) {
             cell.classList.add('empty');
+            cell.addEventListener('click', (event) => {
+              if (event.detail > 1) return;
+              event.preventDefault();
+              scrollMainCalendarToMonth(year, month, { smooth: true });
+              hideMiniTooltip();
+            });
+            cell.addEventListener('dblclick', (event) => {
+              event.preventDefault();
+              scrollMainCalendarToMonth(year, month, { smooth: false });
+              hideMiniTooltip();
+            });
+            cell.addEventListener('mouseleave', hideMiniTooltip);
             grid.appendChild(cell);
             continue;
           }
@@ -2588,7 +2627,7 @@
         const timeout = setTimeout(() => {
           dayEl.classList.remove('highlight-pulse');
           dayHighlightTimers.delete(dateKey);
-        }, 1300);
+        }, 1950);
         dayHighlightTimers.set(dateKey, timeout);
       };
       if (delay > 0) {
@@ -2817,7 +2856,7 @@
 
             const tintStrong = hexToRgba(taskColor, 0.38);
             const tintSoft = hexToRgba(taskColor, 0.14);
-            const outlineColor = task.missionCritical ? 'rgba(255, 196, 0, 0.85)' : hexToRgba(taskColor, 0.55);
+            const outlineColor = hexToRgba(taskColor, 0.55);
             taskCard.style.setProperty('--task-tint-strong', tintStrong);
             taskCard.style.setProperty('--task-tint-soft', tintSoft);
             taskCard.style.setProperty('--task-outline', outlineColor);


### PR DESCRIPTION
## Summary
- center the rolling start time picker on noon by default so midday slots are visible immediately
- extend the calendar highlight pulse and update mini calendar empty cells to align the main view when clicked
- refresh mission critical task styling and category chips for better readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9b3c5c0e4832e8334acfe35dcf0a7