### PR TITLE
Improve timeline scheduling UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       --radius-lg: 22px;
       --radius-md: 16px;
       --radius-sm: 12px;
-      --timeline-hour-height: 20px;
+      --timeline-hour-height: 48px;
     }
 
     * {
@@ -750,6 +750,11 @@
       box-shadow: 0 8px 16px rgba(0, 0, 0, 0.28);
     }
 
+    .task-preview-bar.is-complete {
+      opacity: 0.45;
+      filter: saturate(0.6);
+    }
+
     .task-preview-empty {
       font-size: 11px;
       color: rgba(255, 255, 255, 0.35);
@@ -779,39 +784,64 @@
       z-index: 40;
     }
 
+    .timeline-day-label {
+      font-size: 12px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.68);
+      margin-bottom: 6px;
+    }
+
     .day-timeline {
+      --timeline-focus-bg: rgba(255, 255, 255, 0.04);
+      --timeline-focus-border: rgba(255, 255, 255, 0.08);
+      --timeline-focus-grid: rgba(255, 255, 255, 0.12);
       display: grid;
       grid-template-columns: 52px 1fr;
-      align-items: stretch;
+      align-items: start;
       gap: 16px;
+      max-height: calc(var(--timeline-hour-height) * 12);
+      overflow-y: auto;
+      padding-right: 6px;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+    }
+
+    .day-timeline::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .day-timeline::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.2);
+      border-radius: 999px;
     }
 
     .timeline-hours {
       position: relative;
       display: grid;
-      grid-template-rows: repeat(24, 1fr);
+      grid-template-rows: repeat(24, var(--timeline-hour-height));
       height: calc(var(--timeline-hour-height) * 24);
       font-size: 11px;
       font-variant-numeric: tabular-nums;
-      color: rgba(255, 255, 255, 0.45);
+      color: rgba(255, 255, 255, 0.52);
       text-align: right;
-      padding-right: 6px;
+      padding-right: 8px;
       pointer-events: none;
     }
 
     .timeline-hours span {
-      position: relative;
-      top: -5px;
+      align-self: start;
+      transform: translateY(6px);
     }
 
     .timeline-track {
       position: relative;
       height: calc(var(--timeline-hour-height) * 24);
       border-radius: var(--radius-md);
-      background: rgba(255, 255, 255, 0.04);
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: var(--timeline-focus-bg);
+      border: 1px solid var(--timeline-focus-border);
       overflow: hidden;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
       cursor: crosshair;
       isolation: isolate;
     }
@@ -824,11 +854,11 @@
         to bottom,
         transparent,
         transparent calc(var(--timeline-hour-height) - 1px),
-        rgba(255, 255, 255, 0.07) calc(var(--timeline-hour-height) - 1px),
-        rgba(255, 255, 255, 0.07) var(--timeline-hour-height)
+        var(--timeline-focus-grid) calc(var(--timeline-hour-height) - 1px),
+        var(--timeline-focus-grid) var(--timeline-hour-height)
       );
       pointer-events: none;
-      opacity: 0.5;
+      opacity: 0.6;
     }
 
     .timeline-track::after {
@@ -841,65 +871,84 @@
 
     .timeline-event {
       position: absolute;
-      margin: 0 3px;
-      border-radius: 16px;
-      padding: 10px 12px;
+      margin: 0 4px;
+      border-radius: 12px;
+      padding: 1px 6px;
       display: flex;
-      flex-direction: column;
+      align-items: center;
+      justify-content: space-between;
       gap: 6px;
-      min-height: 32px;
       cursor: grab;
       background:
         linear-gradient(135deg, var(--event-color-strong, rgba(255, 255, 255, 0.18)), var(--event-color-soft, rgba(255, 255, 255, 0.05))),
-        rgba(15, 15, 24, 0.78);
-      border-left: 3px solid var(--event-outline, rgba(255, 255, 255, 0.28));
-      box-shadow: 0 18px 28px rgba(0, 0, 0, 0.42);
+        rgba(15, 15, 24, 0.82);
+      box-shadow: 0 14px 24px rgba(0, 0, 0, 0.38);
       color: var(--text);
-      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, opacity 0.15s ease;
       z-index: 2;
     }
 
     .timeline-event:hover {
       transform: translateY(-1px);
-      box-shadow: 0 22px 36px rgba(0, 0, 0, 0.5);
+      box-shadow: 0 18px 30px rgba(0, 0, 0, 0.45);
       background:
         linear-gradient(135deg, var(--event-color-strong, rgba(255, 255, 255, 0.24)), var(--event-color-soft, rgba(255, 255, 255, 0.08))),
         rgba(18, 18, 28, 0.86);
-      border-color: var(--event-outline, rgba(255, 255, 255, 0.35));
     }
 
     .timeline-event:active,
     .timeline-event.is-dragging {
       cursor: grabbing;
       transform: scale(0.99);
-      box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 14px 26px rgba(0, 0, 0, 0.42);
     }
 
     .timeline-event.mission-critical {
-      border-color: var(--event-outline, rgba(255, 255, 255, 0.42));
-      box-shadow: 0 20px 34px rgba(0, 0, 0, 0.48);
+      box-shadow: 0 16px 28px rgba(0, 0, 0, 0.46);
+    }
+
+    .timeline-event.is-complete {
+      opacity: 0.48;
     }
 
     .timeline-event-title {
+      flex: 1;
       font-weight: 600;
-      font-size: 13px;
-      letter-spacing: 0.01em;
+      font-size: 10px;
+      letter-spacing: 0.04em;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
-    .timeline-event-time {
-      font-size: 11px;
+    .timeline-event-done {
+      appearance: none;
+      border: 1px solid rgba(255, 255, 255, 0.24);
+      background: rgba(0, 0, 0, 0.15);
+      color: var(--text);
+      border-radius: 999px;
+      padding: 0 6px;
+      font-size: 10px;
+      font-weight: 600;
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      color: rgba(255, 255, 255, 0.72);
+      cursor: pointer;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+      line-height: 1.2;
+      flex-shrink: 0;
     }
 
-    .timeline-event-category {
-      font-size: 11px;
-      letter-spacing: 0.02em;
-      color: rgba(255, 255, 255, 0.55);
+    .timeline-event-done:hover,
+    .timeline-event-done:focus-visible {
+      background: rgba(255, 255, 255, 0.18);
+      border-color: rgba(255, 255, 255, 0.32);
+      outline: none;
+    }
+
+    .timeline-event-done[aria-pressed='true'] {
+      background: rgba(255, 255, 255, 0.28);
+      border-color: rgba(255, 255, 255, 0.4);
+      color: rgba(14, 14, 20, 0.85);
     }
 
     .timeline-drop-indicator {
@@ -1579,6 +1628,8 @@
 
     const timelineSnapMinutes = 15;
     const defaultTimelineDuration = 60;
+    const visibleTimelineHours = 12;
+    const defaultTimelineStartHour = 7;
 
     function defaultCategories() {
       return [
@@ -1596,7 +1647,8 @@
         categories,
         nextTaskId: 1,
         nextProjectId: 1,
-        nextCategoryId: categories.length + 1
+        nextCategoryId: categories.length + 1,
+        lastSelectedCategory: categories[0]?.name || ''
       };
     };
 
@@ -1622,6 +1674,12 @@
           parsed.nextCategoryId = maxId + 1;
         }
         migrateTaskData(parsed);
+        if (typeof parsed.lastSelectedCategory !== 'string') {
+          parsed.lastSelectedCategory = '';
+        }
+        if (!parsed.lastSelectedCategory) {
+          parsed.lastSelectedCategory = parsed.categories[0]?.name || '';
+        }
         if (migratedFromLegacy) {
           try {
             localStorage.removeItem(legacyStorageKey);
@@ -1723,6 +1781,7 @@
           delete task.color;
 
           task.missionCritical = Boolean(task.missionCritical);
+          task.completed = Boolean(task.completed);
         });
         state.tasks[dateKey] = tasks.filter(Boolean).sort(compareTasks);
         if (state.tasks[dateKey].length === 0) {
@@ -1754,7 +1813,7 @@
     }
 
     function formatTime(date) {
-      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
     }
 
     function formatDuration(minutes) {
@@ -2377,7 +2436,7 @@
       deleteCategoryBtn.setAttribute('aria-disabled', String(disabled));
     }
 
-    function populateCategorySelect(selectedName, forceNew = false) {
+    function populateCategorySelect(selectedName, { forceNew = false, fallbackName = null } = {}) {
       const sorted = getSortedCategories();
 
       taskCategorySelect.innerHTML = '';
@@ -2393,12 +2452,15 @@
       newOption.textContent = 'Add new category…';
       taskCategorySelect.appendChild(newOption);
 
+      const findMatch = (name) => sorted.find((category) => category.name === name)?.name || null;
+
       let nextValue;
       if (forceNew) {
         nextValue = '__new__';
       } else if (selectedName) {
-        const match = sorted.find((category) => category.name === selectedName);
-        nextValue = match ? match.name : (sorted[0]?.name || '__new__');
+        nextValue = findMatch(selectedName) || findMatch(fallbackName) || (sorted[0]?.name || '__new__');
+      } else if (fallbackName) {
+        nextValue = findMatch(fallbackName) || (sorted[0]?.name || '__new__');
       } else {
         nextValue = sorted[0] ? sorted[0].name : '__new__';
       }
@@ -2452,7 +2514,8 @@
       newCategoryNameInput.value = '';
       newCategoryColorInput.value = '';
       const categorySelection = task?.category || defaults.category || null;
-      populateCategorySelect(categorySelection);
+      const fallbackCategory = defaults.category || state.lastSelectedCategory || null;
+      populateCategorySelect(categorySelection, { fallbackName: fallbackCategory });
 
         if (task && taskCategorySelect.value === '__new__') {
           newCategoryNameInput.value = task.category || '';
@@ -2833,6 +2896,9 @@
       calendarGridEl.innerHTML = '';
       const months = buildMonthSequence();
       const realTodayKey = formatDateKey(new Date());
+      const timelineHourHeightPx = Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--timeline-hour-height')
+      ) || 0;
 
       months.forEach(({ year, month }) => {
         const monthBlock = document.createElement('div');
@@ -2888,7 +2954,7 @@
 
           cell.addEventListener('pointerdown', (event) => {
             if (event.button !== 0 || !event.shiftKey) return;
-            if (event.target.closest('.task-card') || event.target.closest('.task-flyout') || event.target.closest('.add-task-btn') || event.target.closest('.focus-badge')) {
+            if (event.target.closest('.task-flyout') || event.target.closest('.add-task-btn')) {
               return;
             }
             event.preventDefault();
@@ -2944,46 +3010,17 @@
           cell.appendChild(header);
 
           const activeProjects = state.projects.filter((project) => project.start <= dateKey && project.end >= dateKey);
+          const focusColor = activeProjects[0]?.color || null;
           const focusTooltipText = activeProjects.map((project) => project.name).join('\n');
 
           const overlayStack = document.createElement('div');
           overlayStack.className = 'focus-overlay-stack';
-          const focusBadges = document.createElement('div');
-          focusBadges.className = 'focus-badges';
           activeProjects.forEach((project) => {
             const overlay = document.createElement('div');
             overlay.className = 'focus-overlay';
             overlay.style.background = hexToRgba(project.color, 0.18);
             overlayStack.appendChild(overlay);
-
-            const badge = document.createElement('button');
-            badge.type = 'button';
-            badge.className = 'focus-badge';
-            const dot = document.createElement('span');
-            dot.className = 'focus-badge-dot';
-            dot.style.background = project.color;
-            badge.appendChild(dot);
-            const label = document.createElement('span');
-            label.textContent = project.name;
-            badge.appendChild(label);
-            badge.addEventListener('click', (event) => {
-              event.stopPropagation();
-              hideMiniTooltip();
-              openFocusModal(project);
-            });
-            badge.addEventListener('keydown', (event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                hideMiniTooltip();
-                openFocusModal(project);
-              }
-            });
-            focusBadges.appendChild(badge);
           });
-
-          if (activeProjects.length > 0) {
-            focusBadges.classList.add('active');
-          }
 
           cell.appendChild(overlayStack);
 
@@ -3006,17 +3043,9 @@
             preview.className = 'task-preview';
           }
 
-          const taskList = document.createElement('div');
-          taskList.className = 'task-list';
-
           const scheduledEvents = [];
 
           tasks.forEach((task) => {
-            const taskCard = document.createElement('div');
-            taskCard.className = 'task-card';
-            taskCard.draggable = true;
-            taskCard.dataset.taskId = task.id;
-
             const category = getCategoryByName(task.category) || ensureGeneralCategoryExists();
             const baseColor = category?.color || '#6A5ACD';
             const durationMinutes = Math.max(0, Number(task.duration) || 0);
@@ -3029,104 +3058,15 @@
               if (task.missionCritical) {
                 previewBar.classList.add('mission-critical');
               }
+              if (task.completed) {
+                previewBar.classList.add('is-complete');
+              }
               preview.appendChild(previewBar);
             }
 
             const tintStrong = hexToRgba(taskColor, 0.38);
             const tintSoft = hexToRgba(taskColor, 0.14);
             const outlineColor = hexToRgba(taskColor, 0.55);
-            taskCard.style.setProperty('--task-tint-strong', tintStrong);
-            taskCard.style.setProperty('--task-tint-soft', tintSoft);
-            taskCard.style.setProperty('--task-outline', outlineColor);
-            taskCard.style.setProperty('--task-dot', taskColor);
-
-            if (task.missionCritical) {
-              taskCard.classList.add('mission-critical');
-            }
-
-            taskCard.addEventListener('dragstart', (event) => {
-              draggedTask = { id: task.id, fromDate: dateKey };
-              event.dataTransfer.effectAllowed = 'move';
-              event.dataTransfer.setData('text/plain', String(task.id));
-              taskCard.classList.add('is-dragging');
-            });
-
-            taskCard.addEventListener('dragend', () => {
-              clearDragState();
-            });
-
-            taskCard.addEventListener('dblclick', () => {
-              openTaskModal(dateKey, task);
-            });
-
-            const title = document.createElement('div');
-            title.className = 'task-title';
-
-            const colorDot = document.createElement('span');
-            colorDot.className = 'task-dot';
-            colorDot.style.background = taskColor;
-            title.appendChild(colorDot);
-
-            const name = document.createElement('span');
-            name.className = 'task-name';
-            name.textContent = task.title;
-            title.appendChild(name);
-
-            const timeRange = getTaskTimeRange(task);
-            if (timeRange) {
-              const timeEl = document.createElement('span');
-              timeEl.className = 'task-time';
-              timeEl.textContent = timeRange;
-              title.appendChild(timeEl);
-            }
-
-            taskCard.appendChild(title);
-
-            const meta = document.createElement('div');
-            meta.className = 'task-meta';
-            const detailRow = document.createElement('div');
-            detailRow.className = 'task-detail-row';
-
-            if (category) {
-              const categoryDetail = document.createElement('span');
-              categoryDetail.className = 'task-detail';
-              categoryDetail.textContent = category.name;
-              detailRow.appendChild(categoryDetail);
-            }
-
-            if (durationMinutes > 0) {
-              const durationDetail = document.createElement('span');
-              durationDetail.className = 'task-detail';
-              durationDetail.textContent = `Duration ${formatDuration(durationMinutes)}`;
-              detailRow.appendChild(durationDetail);
-            }
-
-            if (task.missionCritical) {
-              const missionDetail = document.createElement('span');
-              missionDetail.className = 'task-detail mission-critical';
-              missionDetail.textContent = 'Mission critical';
-              detailRow.appendChild(missionDetail);
-            }
-
-            if (detailRow.children.length) {
-              meta.appendChild(detailRow);
-            }
-
-            if (task.notes) {
-              const firstLine = task.notes.split(/\r?\n/)[0].trim();
-              if (firstLine) {
-                const notesLine = document.createElement('div');
-                notesLine.className = 'task-note-line';
-                notesLine.textContent = firstLine;
-                meta.appendChild(notesLine);
-              }
-            }
-
-            if (meta.children.length) {
-              taskCard.appendChild(meta);
-            }
-
-            taskList.appendChild(taskCard);
 
             const startMinutes = timeStringToMinutes(task.start);
             if (startMinutes != null && durationMinutes > 0) {
@@ -3139,26 +3079,31 @@
                 tintStrong,
                 tintSoft,
                 outlineColor,
-                missionCritical: Boolean(task.missionCritical)
+                missionCritical: Boolean(task.missionCritical),
+                completed: Boolean(task.completed)
               });
             }
           });
 
-          if (!hasTasks) {
-            const emptyState = document.createElement('div');
-            emptyState.className = 'empty-state';
-            emptyState.textContent = 'No tasks planned yet. Double-click the timeline to add one.';
-            taskList.appendChild(emptyState);
-          }
-
           const flyout = document.createElement('div');
           flyout.className = 'task-flyout';
-          if (activeProjects.length > 0) {
-            flyout.appendChild(focusBadges);
-          }
+
+          const dayLabel = document.createElement('div');
+          dayLabel.className = 'timeline-day-label';
+          dayLabel.textContent = formatFullDate(parseDateKey(dateKey));
+          flyout.appendChild(dayLabel);
 
           const timelineWrapper = document.createElement('div');
           timelineWrapper.className = 'day-timeline';
+          if (focusColor) {
+            timelineWrapper.style.setProperty('--timeline-focus-bg', hexToRgba(focusColor, 0.18));
+            timelineWrapper.style.setProperty('--timeline-focus-border', hexToRgba(focusColor, 0.4));
+            timelineWrapper.style.setProperty('--timeline-focus-grid', hexToRgba(focusColor, 0.32));
+          } else {
+            timelineWrapper.style.removeProperty('--timeline-focus-bg');
+            timelineWrapper.style.removeProperty('--timeline-focus-border');
+            timelineWrapper.style.removeProperty('--timeline-focus-grid');
+          }
 
           const hoursColumn = document.createElement('div');
           hoursColumn.className = 'timeline-hours';
@@ -3214,6 +3159,9 @@
               if (eventInfo.missionCritical) {
                 eventEl.classList.add('mission-critical');
               }
+              if (eventInfo.completed) {
+                eventEl.classList.add('is-complete');
+              }
 
               eventEl.style.top = `${(eventInfo.startMinutes / (24 * 60)) * 100}%`;
               eventEl.style.height = `${(eventInfo.durationMinutes / (24 * 60)) * 100}%`;
@@ -3223,9 +3171,15 @@
               eventEl.style.setProperty('--event-color-soft', eventInfo.tintSoft);
               eventEl.style.setProperty('--event-outline', eventInfo.outlineColor);
 
-              const ariaParts = [eventInfo.title, getTaskTimeRange(eventInfo.task), formatDuration(eventInfo.durationMinutes)];
+              const ariaParts = [eventInfo.title];
+              const timeRange = getTaskTimeRange(eventInfo.task);
+              if (timeRange) ariaParts.push(timeRange);
+              ariaParts.push(formatDuration(eventInfo.durationMinutes));
               if (eventInfo.categoryName) {
                 ariaParts.push(eventInfo.categoryName);
+              }
+              if (eventInfo.completed) {
+                ariaParts.push('Completed');
               }
               eventEl.setAttribute('aria-label', ariaParts.filter(Boolean).join(', '));
 
@@ -3247,6 +3201,7 @@
               });
 
               eventEl.addEventListener('keydown', (event) => {
+                if (event.target !== eventEl) return;
                 if (event.key === 'Enter' || event.key === ' ') {
                   event.preventDefault();
                   openTaskModal(dateKey, eventInfo.task);
@@ -3258,18 +3213,28 @@
               titleEl.textContent = eventInfo.title;
               eventEl.appendChild(titleEl);
 
-              const timeEl = document.createElement('div');
-              timeEl.className = 'timeline-event-time';
-              timeEl.textContent = getTaskTimeRange(eventInfo.task);
-              eventEl.appendChild(timeEl);
-
-              const detailEl = document.createElement('div');
-              detailEl.className = 'timeline-event-category';
-              const detailParts = [];
-              if (eventInfo.categoryName) detailParts.push(eventInfo.categoryName);
-              detailParts.push(formatDuration(eventInfo.durationMinutes));
-              detailEl.textContent = detailParts.join(' • ');
-              eventEl.appendChild(detailEl);
+              const doneButton = document.createElement('button');
+              doneButton.type = 'button';
+              doneButton.className = 'timeline-event-done';
+              doneButton.textContent = 'Done';
+              doneButton.setAttribute('aria-pressed', eventInfo.completed ? 'true' : 'false');
+              doneButton.addEventListener('pointerdown', (event) => {
+                event.stopPropagation();
+              });
+              doneButton.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const taskRecord = getTaskById(dateKey, eventInfo.task.id);
+                if (!taskRecord) return;
+                taskRecord.completed = !taskRecord.completed;
+                saveState();
+                renderCalendar();
+              });
+              doneButton.addEventListener('dblclick', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              });
+              eventEl.appendChild(doneButton);
 
               timelineTrack.appendChild(eventEl);
             });
@@ -3329,7 +3294,10 @@
 
           timelineWrapper.appendChild(timelineTrack);
           flyout.appendChild(timelineWrapper);
-          flyout.appendChild(taskList);
+          const effectiveHourHeight = timelineHourHeightPx || 48;
+          const maxScroll = Math.max(0, (24 - visibleTimelineHours) * effectiveHourHeight);
+          const desiredScroll = defaultTimelineStartHour * effectiveHourHeight;
+          timelineWrapper.scrollTop = Math.max(0, Math.min(desiredScroll, maxScroll));
           flyout.addEventListener('mouseenter', hideMiniTooltip);
           cell.appendChild(flyout);
 
@@ -3412,9 +3380,7 @@
 
     function formatHourLabel(hour) {
       const normalized = ((Number(hour) || 0) % 24 + 24) % 24;
-      const suffix = normalized < 12 ? 'a' : 'p';
-      const display = normalized % 12 === 0 ? 12 : normalized % 12;
-      return `${display}${suffix}`;
+      return `${String(normalized).padStart(2, '0')}:00`;
     }
 
     function getTimelineMinutesFromPointer(event, track) {
@@ -3535,7 +3501,8 @@
             }
           });
         });
-        populateCategorySelect(general.name);
+        state.lastSelectedCategory = general.name;
+        populateCategorySelect(general.name, { fallbackName: general.name });
         saveState();
         renderCalendar();
       });
@@ -3582,6 +3549,8 @@
         categoryName = ensureGeneralCategoryExists().name;
       }
 
+      state.lastSelectedCategory = categoryName;
+
       const start = (formData.get('start') || '').trim();
       const durationRaw = formData.get('duration');
       let durationValue = null;
@@ -3613,7 +3582,7 @@
         }
       } else {
         const taskId = state.nextTaskId++;
-        ensureTasks(editingDate).push({ id: taskId, ...payload });
+        ensureTasks(editingDate).push({ id: taskId, completed: false, ...payload });
       }
 
       ensureTasks(editingDate).sort(compareTasks);


### PR DESCRIPTION
## Summary
- remember the last selected category when creating a new task
- restyle the day timeline with a 12-hour scrollable 24h view that reflects focus colors
- simplify timeline chits to names with completion toggles and remove the duplicate task list

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db02302380832e809e840151516bb6