### PR TITLE
Revamp timeline flyout layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
       transform: translate(-50%, 12px);
       width: clamp(260px, 32vw, 360px);
       max-height: clamp(320px, 65vh, 700px);
-      padding: 20px;
+      padding: 22px;
       border-radius: var(--radius-lg);
       border: 1px solid rgba(255, 255, 255, 0.16);
       background: rgba(18, 18, 28, 0.96);
@@ -774,9 +774,75 @@
       pointer-events: none;
       display: flex;
       flex-direction: column;
-      gap: 16px;
+      gap: 18px;
       transition: opacity 0.3s ease, transform 0.3s ease;
       z-index: 40;
+    }
+
+    .task-flyout-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .task-flyout-date {
+      font-family: 'Space Grotesk', 'Inter', sans-serif;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+
+    .task-flyout-today {
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.75);
+    }
+
+    .timeline-unscheduled {
+      display: grid;
+      gap: 10px;
+    }
+
+    .timeline-unscheduled-label {
+      font-size: 11px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.55);
+    }
+
+    .timeline-unscheduled-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .timeline-unscheduled-chip {
+      appearance: none;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      background:
+        linear-gradient(140deg, var(--chip-strong, rgba(255, 255, 255, 0.18)), var(--chip-soft, rgba(255, 255, 255, 0.05)));
+      color: var(--text);
+      border-radius: 999px;
+      padding: 6px 14px;
+      font-size: 12px;
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+      box-shadow: 0 10px 18px rgba(0, 0, 0, 0.32);
+    }
+
+    .timeline-unscheduled-chip:hover,
+    .timeline-unscheduled-chip:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 28px rgba(0, 0, 0, 0.4);
+      border-color: rgba(255, 255, 255, 0.28);
+      outline: none;
     }
 
     .day-timeline {
@@ -842,30 +908,55 @@
     .timeline-event {
       position: absolute;
       margin: 0 3px;
-      border-radius: 16px;
-      padding: 10px 12px;
+      border-radius: 18px;
+      padding: 14px 16px;
       display: flex;
       flex-direction: column;
-      gap: 6px;
+      gap: 10px;
       min-height: 32px;
       cursor: grab;
       background:
-        linear-gradient(135deg, var(--event-color-strong, rgba(255, 255, 255, 0.18)), var(--event-color-soft, rgba(255, 255, 255, 0.05))),
-        rgba(15, 15, 24, 0.78);
-      border-left: 3px solid var(--event-outline, rgba(255, 255, 255, 0.28));
-      box-shadow: 0 18px 28px rgba(0, 0, 0, 0.42);
+        linear-gradient(160deg, rgba(255, 255, 255, 0.22), transparent 60%),
+        linear-gradient(135deg, var(--event-color-strong, rgba(255, 255, 255, 0.18)), var(--event-color-soft, rgba(255, 255, 255, 0.05)));
+      border: 1px solid var(--event-outline, rgba(255, 255, 255, 0.2));
+      box-shadow: 0 18px 30px rgba(0, 0, 0, 0.42);
       color: var(--text);
-      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
       z-index: 2;
+      isolation: isolate;
+      overflow: hidden;
     }
 
-    .timeline-event:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 22px 36px rgba(0, 0, 0, 0.5);
+    .timeline-event::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: radial-gradient(circle at top, rgba(255, 255, 255, 0.3), transparent 60%);
+      opacity: 0;
+      transition: opacity 0.2s ease;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    .timeline-event > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    .timeline-event:hover,
+    .timeline-event:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 26px 44px rgba(0, 0, 0, 0.5);
+      border-color: rgba(255, 255, 255, 0.28);
       background:
-        linear-gradient(135deg, var(--event-color-strong, rgba(255, 255, 255, 0.24)), var(--event-color-soft, rgba(255, 255, 255, 0.08))),
-        rgba(18, 18, 28, 0.86);
-      border-color: var(--event-outline, rgba(255, 255, 255, 0.35));
+        linear-gradient(155deg, rgba(255, 255, 255, 0.28), transparent 65%),
+        linear-gradient(135deg, var(--event-color-strong, rgba(255, 255, 255, 0.22)), var(--event-color-soft, rgba(255, 255, 255, 0.08)));
+    }
+
+    .timeline-event:hover::before,
+    .timeline-event:focus-visible::before {
+      opacity: 1;
     }
 
     .timeline-event:active,
@@ -876,8 +967,8 @@
     }
 
     .timeline-event.mission-critical {
-      border-color: var(--event-outline, rgba(255, 255, 255, 0.42));
-      box-shadow: 0 20px 34px rgba(0, 0, 0, 0.48);
+      border-color: var(--event-outline, rgba(255, 255, 255, 0.34));
+      box-shadow: 0 22px 38px rgba(0, 0, 0, 0.5);
     }
 
     .timeline-event-title {
@@ -889,17 +980,51 @@
       text-overflow: ellipsis;
     }
 
-    .timeline-event-time {
-      font-size: 11px;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: rgba(255, 255, 255, 0.72);
+    .timeline-event-meta {
+      display: grid;
+      gap: 8px;
+      max-height: 0;
+      opacity: 0;
+      overflow: hidden;
+      transform: translateY(6px);
+      transition: opacity 0.18s ease, transform 0.18s ease, max-height 0.18s ease;
+      pointer-events: none;
     }
 
-    .timeline-event-category {
-      font-size: 11px;
-      letter-spacing: 0.02em;
-      color: rgba(255, 255, 255, 0.55);
+    .timeline-event:hover .timeline-event-meta,
+    .timeline-event:focus-visible .timeline-event-meta {
+      max-height: 320px;
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    }
+
+    .timeline-event-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .timeline-event-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 10px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      background: rgba(12, 12, 20, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      color: rgba(255, 255, 255, 0.75);
+      box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
+    }
+
+    .timeline-event-note {
+      font-size: 12px;
+      line-height: 1.5;
+      color: rgba(255, 255, 255, 0.82);
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
     }
 
     .timeline-drop-indicator {
@@ -3006,17 +3131,10 @@
             preview.className = 'task-preview';
           }
 
-          const taskList = document.createElement('div');
-          taskList.className = 'task-list';
-
           const scheduledEvents = [];
+          const unscheduledTasks = [];
 
           tasks.forEach((task) => {
-            const taskCard = document.createElement('div');
-            taskCard.className = 'task-card';
-            taskCard.draggable = true;
-            taskCard.dataset.taskId = task.id;
-
             const category = getCategoryByName(task.category) || ensureGeneralCategoryExists();
             const baseColor = category?.color || '#6A5ACD';
             const durationMinutes = Math.max(0, Number(task.duration) || 0);
@@ -3035,98 +3153,9 @@
             const tintStrong = hexToRgba(taskColor, 0.38);
             const tintSoft = hexToRgba(taskColor, 0.14);
             const outlineColor = hexToRgba(taskColor, 0.55);
-            taskCard.style.setProperty('--task-tint-strong', tintStrong);
-            taskCard.style.setProperty('--task-tint-soft', tintSoft);
-            taskCard.style.setProperty('--task-outline', outlineColor);
-            taskCard.style.setProperty('--task-dot', taskColor);
-
-            if (task.missionCritical) {
-              taskCard.classList.add('mission-critical');
-            }
-
-            taskCard.addEventListener('dragstart', (event) => {
-              draggedTask = { id: task.id, fromDate: dateKey };
-              event.dataTransfer.effectAllowed = 'move';
-              event.dataTransfer.setData('text/plain', String(task.id));
-              taskCard.classList.add('is-dragging');
-            });
-
-            taskCard.addEventListener('dragend', () => {
-              clearDragState();
-            });
-
-            taskCard.addEventListener('dblclick', () => {
-              openTaskModal(dateKey, task);
-            });
-
-            const title = document.createElement('div');
-            title.className = 'task-title';
-
-            const colorDot = document.createElement('span');
-            colorDot.className = 'task-dot';
-            colorDot.style.background = taskColor;
-            title.appendChild(colorDot);
-
-            const name = document.createElement('span');
-            name.className = 'task-name';
-            name.textContent = task.title;
-            title.appendChild(name);
-
-            const timeRange = getTaskTimeRange(task);
-            if (timeRange) {
-              const timeEl = document.createElement('span');
-              timeEl.className = 'task-time';
-              timeEl.textContent = timeRange;
-              title.appendChild(timeEl);
-            }
-
-            taskCard.appendChild(title);
-
-            const meta = document.createElement('div');
-            meta.className = 'task-meta';
-            const detailRow = document.createElement('div');
-            detailRow.className = 'task-detail-row';
-
-            if (category) {
-              const categoryDetail = document.createElement('span');
-              categoryDetail.className = 'task-detail';
-              categoryDetail.textContent = category.name;
-              detailRow.appendChild(categoryDetail);
-            }
-
-            if (durationMinutes > 0) {
-              const durationDetail = document.createElement('span');
-              durationDetail.className = 'task-detail';
-              durationDetail.textContent = `Duration ${formatDuration(durationMinutes)}`;
-              detailRow.appendChild(durationDetail);
-            }
-
-            if (task.missionCritical) {
-              const missionDetail = document.createElement('span');
-              missionDetail.className = 'task-detail mission-critical';
-              missionDetail.textContent = 'Mission critical';
-              detailRow.appendChild(missionDetail);
-            }
-
-            if (detailRow.children.length) {
-              meta.appendChild(detailRow);
-            }
-
-            if (task.notes) {
-              const firstLine = task.notes.split(/\r?\n/)[0].trim();
-              if (firstLine) {
-                const notesLine = document.createElement('div');
-                notesLine.className = 'task-note-line';
-                notesLine.textContent = firstLine;
-                meta.appendChild(notesLine);
-              }
-            }
-
-            if (meta.children.length) {
-              taskCard.appendChild(meta);
-            }
-
-            taskList.appendChild(taskCard);
+            const firstNoteLine = task.notes
+              ? (task.notes.split(/\r?\n/).find((line) => line.trim().length > 0) || '').trim()
+              : '';
 
             const startMinutes = timeStringToMinutes(task.start);
             if (startMinutes != null && durationMinutes > 0) {
@@ -3139,22 +3168,72 @@
                 tintStrong,
                 tintSoft,
                 outlineColor,
-                missionCritical: Boolean(task.missionCritical)
+                missionCritical: Boolean(task.missionCritical),
+                note: firstNoteLine
+              });
+            } else {
+              unscheduledTasks.push({
+                task,
+                color: taskColor,
+                note: firstNoteLine,
+                categoryName: category?.name || ''
               });
             }
           });
 
-          if (!hasTasks) {
-            const emptyState = document.createElement('div');
-            emptyState.className = 'empty-state';
-            emptyState.textContent = 'No tasks planned yet. Double-click the timeline to add one.';
-            taskList.appendChild(emptyState);
-          }
-
           const flyout = document.createElement('div');
           flyout.className = 'task-flyout';
+          const flyoutHeader = document.createElement('div');
+          flyoutHeader.className = 'task-flyout-header';
+          const flyoutDate = document.createElement('div');
+          flyoutDate.className = 'task-flyout-date';
+          flyoutDate.textContent = formatFullDate(parseDateKey(dateKey));
+          flyoutHeader.appendChild(flyoutDate);
+          if (dateKey === realTodayKey) {
+            const todayBadge = document.createElement('span');
+            todayBadge.className = 'task-flyout-today';
+            todayBadge.textContent = 'Today';
+            flyoutHeader.appendChild(todayBadge);
+          }
+          flyout.appendChild(flyoutHeader);
           if (activeProjects.length > 0) {
             flyout.appendChild(focusBadges);
+          }
+
+          if (unscheduledTasks.length > 0) {
+            const unscheduledWrapper = document.createElement('div');
+            unscheduledWrapper.className = 'timeline-unscheduled';
+            const unscheduledLabel = document.createElement('span');
+            unscheduledLabel.className = 'timeline-unscheduled-label';
+            unscheduledLabel.textContent = 'Unscheduled tasks';
+            unscheduledWrapper.appendChild(unscheduledLabel);
+            const unscheduledChips = document.createElement('div');
+            unscheduledChips.className = 'timeline-unscheduled-chips';
+            unscheduledTasks.forEach(({ task, color, note, categoryName }) => {
+              const chip = document.createElement('button');
+              chip.type = 'button';
+              chip.className = 'timeline-unscheduled-chip';
+              chip.textContent = task.title;
+              chip.style.setProperty('--chip-strong', hexToRgba(color, 0.4));
+              chip.style.setProperty('--chip-soft', hexToRgba(color, 0.12));
+              const chipParts = [task.title];
+              if (categoryName) chipParts.push(categoryName);
+              if (note) chipParts.push(note);
+              chip.title = chipParts.join(' • ');
+              chip.setAttribute('aria-label', `${task.title}${categoryName ? `, ${categoryName}` : ''}${note ? ` — ${note}` : ''}`);
+              chip.addEventListener('click', () => {
+                openTaskModal(dateKey, task);
+              });
+              chip.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  openTaskModal(dateKey, task);
+                }
+              });
+              unscheduledChips.appendChild(chip);
+            });
+            unscheduledWrapper.appendChild(unscheduledChips);
+            flyout.appendChild(unscheduledWrapper);
           }
 
           const timelineWrapper = document.createElement('div');
@@ -3223,11 +3302,13 @@
               eventEl.style.setProperty('--event-color-soft', eventInfo.tintSoft);
               eventEl.style.setProperty('--event-outline', eventInfo.outlineColor);
 
-              const ariaParts = [eventInfo.title, getTaskTimeRange(eventInfo.task), formatDuration(eventInfo.durationMinutes)];
+              const timeRange = getTaskTimeRange(eventInfo.task);
+              const ariaParts = [eventInfo.title, timeRange, formatDuration(eventInfo.durationMinutes)];
               if (eventInfo.categoryName) {
                 ariaParts.push(eventInfo.categoryName);
               }
               eventEl.setAttribute('aria-label', ariaParts.filter(Boolean).join(', '));
+              eventEl.title = ariaParts.filter(Boolean).join(' • ');
 
               eventEl.addEventListener('dragstart', (event) => {
                 draggedTask = { id: eventInfo.task.id, fromDate: dateKey };
@@ -3258,18 +3339,40 @@
               titleEl.textContent = eventInfo.title;
               eventEl.appendChild(titleEl);
 
-              const timeEl = document.createElement('div');
-              timeEl.className = 'timeline-event-time';
-              timeEl.textContent = getTaskTimeRange(eventInfo.task);
-              eventEl.appendChild(timeEl);
-
-              const detailEl = document.createElement('div');
-              detailEl.className = 'timeline-event-category';
-              const detailParts = [];
-              if (eventInfo.categoryName) detailParts.push(eventInfo.categoryName);
-              detailParts.push(formatDuration(eventInfo.durationMinutes));
-              detailEl.textContent = detailParts.join(' • ');
-              eventEl.appendChild(detailEl);
+              const metaEl = document.createElement('div');
+              metaEl.className = 'timeline-event-meta';
+              const chipGroup = document.createElement('div');
+              chipGroup.className = 'timeline-event-chips';
+              if (timeRange) {
+                const timeChip = document.createElement('span');
+                timeChip.className = 'timeline-event-chip';
+                timeChip.textContent = timeRange;
+                chipGroup.appendChild(timeChip);
+              }
+              if (eventInfo.categoryName) {
+                const categoryChip = document.createElement('span');
+                categoryChip.className = 'timeline-event-chip';
+                categoryChip.textContent = eventInfo.categoryName;
+                chipGroup.appendChild(categoryChip);
+              }
+              if (eventInfo.durationMinutes > 0) {
+                const durationChip = document.createElement('span');
+                durationChip.className = 'timeline-event-chip';
+                durationChip.textContent = formatDuration(eventInfo.durationMinutes);
+                chipGroup.appendChild(durationChip);
+              }
+              if (chipGroup.children.length) {
+                metaEl.appendChild(chipGroup);
+              }
+              if (eventInfo.note) {
+                const noteEl = document.createElement('div');
+                noteEl.className = 'timeline-event-note';
+                noteEl.textContent = eventInfo.note;
+                metaEl.appendChild(noteEl);
+              }
+              if (metaEl.children.length) {
+                eventEl.appendChild(metaEl);
+              }
 
               timelineTrack.appendChild(eventEl);
             });
@@ -3329,7 +3432,6 @@
 
           timelineWrapper.appendChild(timelineTrack);
           flyout.appendChild(timelineWrapper);
-          flyout.appendChild(taskList);
           flyout.addEventListener('mouseenter', hideMiniTooltip);
           cell.appendChild(flyout);
 


### PR DESCRIPTION
## Summary
- replace the focus heading in the day flyout with a formatted date banner and surface unscheduled items as compact chips
- restyle timeline events with tactile gradients and hover-revealed chips so key details stay hidden until interaction
- remove the legacy task list from the flyout and rely on the timeline plus hover states for schedule context

## Testing
- Not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dfbbf615d8832e831239a0f6aec8f0